### PR TITLE
Recognize and publish `x-` options in manifest

### DIFF
--- a/custom-use-cases/owned-2.0.0/ethpm.json
+++ b/custom-use-cases/owned-2.0.0/ethpm.json
@@ -13,5 +13,6 @@
     "./contracts/*.sol",
     "./contracts/**/*.sol"
   ],
-  "version": "2.0.0"
+  "version": "2.0.0",
+  "x-via": "test-packager"
 }

--- a/lib/publisher.js
+++ b/lib/publisher.js
@@ -35,6 +35,12 @@ Publisher.prototype.publish = function(config, contract_types, deployments, mani
     lockfile.contract_types = contract_types || {};
     lockfile.deployments = deployments || {};
 
+    Object.keys(manifest).filter(function (option) {
+      return option.indexOf('x-') == 0;
+    }).forEach(function (option) {
+      lockfile[option] = manifest[option];
+    });
+
     accept();
   }).then(function() {
     // If no sources and no empty array, assume all solidity files in the source directory (configurable).

--- a/test/test_publish.js
+++ b/test/test_publish.js
@@ -8,10 +8,12 @@ describe("Publishing", function() {
   var helper = TestHelper.setup({
     packages: [
       "custom-use-cases/owned-1.0.0",
+      "custom-use-cases/owned-2.0.0",
       "custom-use-cases/eth-usd-oracle-1.0.0"
     ],
     compile: [
-      "owned-1.0.0"
+      "owned-1.0.0",
+      "owned-2.0.0"
     ]
   });
 
@@ -20,6 +22,7 @@ describe("Publishing", function() {
 
   before("setup variables once previous steps are finished", function() {
     owned = helper.packages["owned-1.0.0"];
+    owned2 = helper.packages["owned-2.0.0"];
     eth_usd = helper.packages["eth-usd-oracle-1.0.0"];
   });
 
@@ -52,6 +55,24 @@ describe("Publishing", function() {
       });
 
       return Promise.all(promises);
+    });
+  });
+
+  it("recognizes x-* options in the manifest and includes them in lockfile", function() {
+    this.timeout(10000);
+
+    var lockfile;
+
+    // Publish the package.
+    return owned2.package.publish(owned2.contract_metadata).then(function() {
+      // Now check the registry
+      return helper.registry.getLockfileURI("owned", "2.0.0");
+    }).then(function(lockfileURI) {
+      return helper.host.get(lockfileURI);
+    }).then(function(data) {
+      lockfile = JSON.parse(data);
+
+      assert.equal(lockfile["x-via"], "test-packager");
     });
   });
 


### PR DESCRIPTION
Additionally:
- Add `x-via` as example to owned-2.0.0 ethpm.json
- Test that `x-via` exists/matches in lockfile