### PR TITLE
Make it better for bundling

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -1,5 +1,4 @@
 var fs = require("fs");
-var requireNoCache = require("./require-nocache");
 var _ = require("lodash");
 var path = require("path");
 

--- a/lib/hosts/ipfshost.js
+++ b/lib/hosts/ipfshost.js
@@ -9,7 +9,6 @@ function IPFSHost(host, port, protocol) {
   this.port = port || 5001;
   this.protocol = protocol || "http";
 
-  // this.ipfs = ipfsAPI(this.host, this.port, {protocol: this.protocol});
   this.ipfs = new IPFS({
     host: this.host,
     port: this.port,

--- a/lib/hosts/ipfshost.js
+++ b/lib/hosts/ipfshost.js
@@ -1,39 +1,43 @@
-var ipfsAPI = require('ipfs-api');
+var IPFS = require("ipfs-mini");
 var wget = require("wget-improved");
 var Readable = require('stream').Readable;
 var URL = require("url");
+var fs = require("fs");
 
 function IPFSHost(host, port, protocol) {
   this.host = host || "localhost";
   this.port = port || 5001;
   this.protocol = protocol || "http";
 
-  this.ipfs = ipfsAPI(this.host, this.port, {protocol: this.protocol});
+  // this.ipfs = ipfsAPI(this.host, this.port, {protocol: this.protocol});
+  this.ipfs = new IPFS({
+    host: this.host,
+    port: this.port,
+    protocol: this.protocol
+  });
 }
 
 IPFSHost.prototype.putContents = function(contents) {
   var self = this;
 
   return new Promise(function(accept, reject) {
-    var stream = new Readable();
-    stream.push(contents);
-    stream.push(null);
-
-    self.ipfs.util.addFromStream(stream, function(err, result) {
+    self.ipfs.add(contents, (err, result) => {
       if (err) return reject(err);
-      accept("ipfs://" + result[0].hash);
-    })
+      accept("ipfs://" + result);
+    });
   });
 }
 
 IPFSHost.prototype.putFile = function(file) {
   var self = this;
+
   return new Promise(function(accept, reject) {
-    self.ipfs.util.addFromFs(file, {recursive: false}, function(err, result) {
+    fs.readFile(file, "utf8", function(err, data) {
       if (err) return reject(err);
-      accept("ipfs://" + result[0].hash);
+
+      self.putContents(data).then(accept).catch(reject);
     });
-  })
+  });
 };
 
 IPFSHost.prototype.get = function(uri) {

--- a/lib/lockfile.js
+++ b/lib/lockfile.js
@@ -1,5 +1,5 @@
-var requireNoCache = require("./require-nocache");
 var V1 = require("./lockfiles/v1");
+var fs = require("fs");
 
 var Lockfile = {
   getInterpreter: function(lockfile_version) {
@@ -26,7 +26,9 @@ var Lockfile = {
     return interpreter;
   },
   read: function(file) {
-    var json = requireNoCache(file);
+    var json = fs.readFileSync(file);
+    json = JSON.parse(json);
+
     var interpreter = this.getInterpreter(json.lockfile_version);
 
     interpreter.validate(json);

--- a/lib/manifest.js
+++ b/lib/manifest.js
@@ -1,4 +1,4 @@
-var requireNoCache = require("./require-nocache");
+var fs = require("fs");
 var V1 = require("./manifests/v1");
 
 var Manifest = {
@@ -26,7 +26,9 @@ var Manifest = {
     return interpreter;
   },
   read: function(file) {
-    var json = requireNoCache(file);
+    var json = fs.readFileSync(file);
+    json = JSON.parse(json);
+
     var interpreter = this.getInterpreter(json.manifest_version);
 
     interpreter.validate(json);

--- a/lib/require-nocache.js
+++ b/lib/require-nocache.js
@@ -1,6 +1,0 @@
-var path = require("path");
-
-module.exports = function(filePath) {
-  delete require.cache[path.resolve(filePath)];
-  return require(filePath);
-};

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "fs-extra": "^1.0.0",
     "glob": "^7.1.1",
     "ipfs": "^0.23.1",
-    "ipfs-api": "^14.0.1",
+    "ipfs-mini": "^1.1.2",
     "jsonschema": "^1.1.1",
     "lodash": "^4.17.1",
     "node-dir": "^0.1.16",


### PR DESCRIPTION
- Use ipfs-mini because it bundles better and has less dependencies

- remove require-nocache, which was just a lazy way of reading a JSON
file from disk.